### PR TITLE
Let successful pdf production provide url

### DIFF
--- a/bakery/pipeline-with-service.yml
+++ b/bakery/pipeline-with-service.yml
@@ -40,7 +40,7 @@ resources:
     type: git
     source:
       uri: https://github.com/openstax/pdf-spike.git
-      branch: event-service-pipeline
+      branch: event-service-pipeline-pdf-url
 
   - name: workflow-events-queued
     type: workflow-events
@@ -52,6 +52,7 @@ resources:
     type: workflow-events
     source:
       api_root: https://cc1.cnx.org/api
+      status_id: 0
 
 jobs:
   - name: fetch-book
@@ -168,3 +169,9 @@ jobs:
           params:
             id: workflow-events-queued/id
             status_id: "4" #Failed
+        on_success:
+          put: event-update
+          params:
+            id: workflow-events-queued/id
+            status_id: "5"
+            pdf_url: artifacts/pdf_url

--- a/bakery/tasks/t-build-pdf.yml
+++ b/bakery/tasks/t-build-pdf.yml
@@ -20,4 +20,4 @@ run:
       exec 2> >(tee s3/book/stderr >&2)
       rm -f artifacts/stderr
       prince -v --output="artifacts/$(cat book-title/name).pdf" "s3/book/collection.assembled.xhtml"
-      echo -n "https://ce-pdf-spike.s3.amazonaws.com/$(book-title/name).pdf" >artifacts/pdf_url
+      echo -n "https://ce-pdf-spike.s3.amazonaws.com/artifacts/$(cat book-title/name).pdf" >artifacts/pdf_url

--- a/bakery/tasks/t-fetch-book.yml
+++ b/bakery/tasks/t-fetch-book.yml
@@ -17,5 +17,5 @@ run:
     - -cxe
     - |
       exec 2> >(tee book/stderr >&2)
-      neb get -r -d "./temp" "staging" "$(cat book-title/collection_id)" "$(cat book-title/version)"
+      neb get -r -d "./temp" "$(cat book-title/server | cut -f1 -d".")" "$(cat book-title/collection_id)" "$(cat book-title/version)"
       mv temp/* book

--- a/workflow-event-resource/src/out.py
+++ b/workflow-event-resource/src/out.py
@@ -19,8 +19,9 @@ def out(src_path, in_stream):
     with open(os.path.join(src_path, id_path), "r") as infile:
         id = infile.read()
 
-    if data.get("pdf_url"):
-        with open(os.path.join(src_path, "artifacts/pdf_url"), "r") as infile:
+    pdf_url = data.get("pdf_url")
+    if pdf_url:
+        with open(os.path.join(src_path, pdf_url), "r") as infile:
             pdf_url = infile.read()
             data["pdf_url"] = pdf_url
 

--- a/workflow-event-resource/src/out.py
+++ b/workflow-event-resource/src/out.py
@@ -15,11 +15,16 @@ def out(src_path, in_stream):
     id_path = data.pop("id")
 
     msg("Input: {}", input)
-    msg("Params: {}", data)
 
     with open(os.path.join(src_path, id_path), "r") as infile:
         id = infile.read()
 
+    if data.get("pdf_url"):
+        with open(os.path.join(src_path, "artifacts/pdf_url"), "r") as infile:
+            pdf_url = infile.read()
+            data["pdf_url"] = pdf_url
+
+    msg("Params: {}", data)
     msg(f"Updating status of event id {id}")
 
     response = update_event(input["source"]["api_root"], id, data)


### PR DESCRIPTION
For Review:
This PR will allow for the concourse pipeline to be triggered by the output producer resource (formerly known as the workflow-event-resource) from cc1.cnx.org, cc2.cnx.org, or cc3.cnx.org.

To Test - 

1.  Update `credentials.yml.template` with the proper credentials. 

2. Navigate to the directory that contains the pipeline configuration file `pipeline-with-service.yml`
```
$ cd /bakery
```

3. Download the Docker Compose file to run Concourse
```
$ wget https://concourse-ci.org/docker-compose.yml
$ docker-compose up -d
Creating docs_concourse-db_1 ...
Creating docs_concourse-db_1 ... done
Creating docs_concourse_1 ...
Creating docs_concourse_1 ... done
Concourse will be running at localhost:8080. You can log in with the username/password as test/test.

Next, install fly CLI by downloading it from the web UI and target your local Concourse as the test user:

$ fly -t pdf-pipeline login -c http://localhost:8080 -u test -p test
logging in to team 'main'

target saved
```

4. Set the Concourse Pipeline
```
fly -t pdf-pipeline set-pipeline -p pdf-producer -c pipeline-with-service.yml -l credentials.yml
```

5. Trigger job by navigating to cc1.cnx.org, cc2.cnx.org, or cc2.cnx.org and "Create a new PDF Job"


When the job is down, it SHOULD produce a pdf url (from the s3 bucket) you can open to view the pdf. 